### PR TITLE
Support database profiling

### DIFF
--- a/python/rubbish/admin/cli.py
+++ b/python/rubbish/admin/cli.py
@@ -17,12 +17,13 @@ def cli():
     pass
 
 @click.command(name="connect", short_help="Shell out to psql.")
-def connect():
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def connect(profile):
     sp = subprocess.run(["which", "psql"], capture_output=True)
     if sp.returncode != 0:
         print("psql not installed, install that first.")
         return
-    connstr = _get_db()
+    connstr = _get_db(profile=profile)
     if connstr == None:
         print("database not set, set that first with set_db")
         return
@@ -30,8 +31,9 @@ def connect():
     os.execl(psql, psql, connstr)
 
 @click.command(name="get-db", short_help="Prints the DB connection string.")
-def get_db():
-    connstr = _get_db()
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def get_db(profile):
+    connstr = _get_db(profile=profile)
     if connstr:
         print(connstr)
     else:
@@ -39,14 +41,16 @@ def get_db():
 
 @click.command(name="set-db", short_help="Set the DB connection string.")
 @click.argument("dbstr")
-def set_db(dbstr):
-    _set_db(dbstr)
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def set_db(dbstr, profile):
+    _set_db(dbstr, profile=profile)
 
 @click.command(name="reset-db", short_help="Reset the DB.")
-def reset_db():
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def reset_db(profile):
     y_n = input("This will delete ALL data currently in the database. Are you sure? [Y/n]: ")
     if y_n == "y" or y_n == "yes" or y_n == "Y":
-        _reset_db()
+        _reset_db(profile=profile)
     elif y_n == "n" or y_n == "no":
         return
     else:
@@ -56,29 +60,34 @@ def reset_db():
 @click.command(name="update-zone", short_help="Write a new zone generation in and reticulates.")
 @click.argument("osmnx_name")
 @click.option("-n", "--name", help="Optional name, otherwise copies osmnx_name.", default=None)
-def update_zone(osmnx_name, name):
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def update_zone(osmnx_name, name, profile):
     if name is None:
         name = osmnx_name
-    _update_zone(osmnx_name, name)
+    _update_zone(osmnx_name, name, profile=profile)
 
 @click.command(name="show-zones", short_help="Pretty-prints zones in the database.")
-def show_zones():
-    _show_zones()
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def show_zones(profile):
+    _show_zones(profile=profile)
 
 @click.command(name="insert-sector", short_help="Inserts a new sector into the database.")
 @click.argument("sector_name")
 @click.argument("filepath")
-def insert_sector(sector_name, filepath):
-    _insert_sector(sector_name, filepath)
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def insert_sector(sector_name, filepath, profile):
+    _insert_sector(sector_name, filepath, profile)
 
 @click.command(name="delete-sector", short_help="Deletes a sector from the database.")
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
 @click.argument("sector_name")
-def delete_sector(sector_name):
-    _delete_sector(sector_name)
+def delete_sector(sector_name, profile):
+    _delete_sector(sector_name, profile=profile)
 
 @click.command(name="show-sectors", short_help="Pretty-prints sectors in the database.")
-def show_sectors():
-    _show_sectors()
+@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+def show_sectors(profile):
+    _show_sectors(profile=profile)
 
 cli.add_command(connect)
 cli.add_command(get_db)

--- a/python/rubbish/admin/ops.py
+++ b/python/rubbish/admin/ops.py
@@ -293,8 +293,6 @@ def insert_sector(sector_name, filepath, profile=None):
         session.close()
 
 def delete_sector(sector_name, profile=None):
-    if profile is None:
-        profile = 'default'
     session = db_sessionmaker(profile=profile)()
 
     sector = session.query(Sector).filter_by(name=sector_name).one_or_none()

--- a/python/rubbish/admin/ops.py
+++ b/python/rubbish/admin/ops.py
@@ -110,7 +110,7 @@ def _calculate_linestring_length(linestring):
         length += distance(linestring.coords[idx_a][::-1], linestring.coords[idx_b][::-1]).meters
     return length
 
-def update_zone(osmnx_name, name, centerlines=None):
+def update_zone(osmnx_name, name, centerlines=None, profile=None):
     """
     Updates a zone, plopping the new centerlines into the database.
 
@@ -118,7 +118,7 @@ def update_zone(osmnx_name, name, centerlines=None):
     
     The optional `centerlines` argument is used to avoid a network request in testing.
     """
-    session = db_sessionmaker()()
+    session = db_sessionmaker(profile=profile)()
 
     # insert zone
     # NOTE: flush writes DB ops to the database's transactional buffer without actually
@@ -223,9 +223,9 @@ def update_zone(osmnx_name, name, centerlines=None):
     finally:
         session.close()
 
-def show_zones():
+def show_zones(profile=None):
     """Pretty-prints a list of zones in the database."""
-    session = db_sessionmaker()()
+    session = db_sessionmaker(profile=profile)()
     zones = (session
         .query(Zone)
         .all()
@@ -271,8 +271,8 @@ def _validate_sector_geom(filepath):
         raise ValueError(f"Input sector has unsupported {sector_shape.geom_type} union type.")
     return sector_shape
 
-def insert_sector(sector_name, filepath):
-    session = db_sessionmaker()()
+def insert_sector(sector_name, filepath, profile=None):
+    session = db_sessionmaker(profile=profile)()
 
     if session.query(Sector).filter_by(name=sector_name).count() != 0:
         raise ValueError(
@@ -292,8 +292,10 @@ def insert_sector(sector_name, filepath):
     finally:
         session.close()
 
-def delete_sector(sector_name):
-    session = db_sessionmaker()()
+def delete_sector(sector_name, profile=None):
+    if profile is None:
+        profile = 'default'
+    session = db_sessionmaker(profile=profile)()
 
     sector = session.query(Sector).filter_by(name=sector_name).one_or_none()
     if sector is None:
@@ -308,9 +310,9 @@ def delete_sector(sector_name):
     finally:
         session.close()
 
-def show_sectors():
+def show_sectors(profile=None):
     """Pretty-prints a list of sectors in the database."""
-    session = db_sessionmaker()()
+    session = db_sessionmaker(profile=profile)()
     
     sectors = session.query(Sector).all()
     if len(sectors) == 0:

--- a/python/rubbish/admin/tests/tests.py
+++ b/python/rubbish/admin/tests/tests.py
@@ -10,10 +10,8 @@ import unittest
 from unittest.mock import patch
 import pytest
 import tempfile
-import os
 
-import rubbish
-from rubbish.common.db_ops import reset_db, db_sessionmaker
+from rubbish.common.db_ops import db_sessionmaker
 from rubbish.common.orm import Zone, ZoneGeneration, Centerline, Sector
 from rubbish.common.test_utils import get_db, clean_db, alias_test_db, insert_grid, get_grid
 from rubbish.admin.ops import update_zone, insert_sector, delete_sector, show_zones, show_sectors

--- a/python/rubbish/common/db_ops.py
+++ b/python/rubbish/common/db_ops.py
@@ -62,9 +62,6 @@ def reset_db(profile=None):
     """
     Resets the current database, deleting all data.
     """
-    if profile is None:
-        profile = 'default'
-
     session = db_sessionmaker(profile=profile)()
 
     engine = session.bind

--- a/python/rubbish/common/test_utils.py
+++ b/python/rubbish/common/test_utils.py
@@ -11,7 +11,8 @@ import rubbish
 from rubbish.common.db_ops import reset_db, db_sessionmaker
 from rubbish.admin.ops import update_zone
 
-get_db = lambda: f"postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish"
+def get_db(profile=None):
+    return f"postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish"
 
 def clean_db(f):
     """


### PR DESCRIPTION
This is a development QOL improvement: it allows you to manage multiple database connection strings easily (e.g. local, dev, prod) which makes it easier to test things locally.